### PR TITLE
Fix OrderResource cleanup

### DIFF
--- a/app/Filament/Resources/OrderResource.php
+++ b/app/Filament/Resources/OrderResource.php
@@ -695,4 +695,3 @@ class OrderResource extends Resource
         }
     }
 }
-\Log::info(request()->all());


### PR DESCRIPTION
## Summary
- remove stray debug log line from OrderResource

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a5ad5fd948323af9d1e4964e44af1