### PR TITLE
Fix relation manager namespace

### DIFF
--- a/app/Filament/Resources/SubscriptionResource/RelationManagers/SubscriptionPackagesRelationManager.php
+++ b/app/Filament/Resources/SubscriptionResource/RelationManagers/SubscriptionPackagesRelationManager.php
@@ -1,12 +1,13 @@
 <?php
 
-namespace App\Filament\Resources;
+namespace App\Filament\Resources\SubscriptionResource\RelationManagers;
 
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
+use App\Models\Package;
 
 class SubscriptionPackagesRelationManager extends RelationManager
 {


### PR DESCRIPTION
## Summary
- correct namespace for SubscriptionPackagesRelationManager
- ensure Package model is imported

## Testing
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684a5ad6ec288323ad204c8824b88666