### PR TITLE
Add staff profile management

### DIFF
--- a/app/Http/Controllers/StaffDashboardController.php
+++ b/app/Http/Controllers/StaffDashboardController.php
@@ -5,6 +5,8 @@
 namespace App\Http\Controllers;
 
 use App\Models\OrderStaff;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
 
 class StaffDashboardController extends Controller
 {
@@ -47,5 +49,48 @@ class StaffDashboardController extends Controller
         ]);
 
         return view('staff.jadwal', compact('events'));
+    }
+
+    public function showProfile()
+    {
+        $user = auth()->user();
+        if (!$user->staff) {
+            abort(403, 'Akun Anda belum terhubung dengan data staff.');
+        }
+
+        $staff = $user->staff;
+
+        return view('staff.profile', compact('staff'));
+    }
+
+    public function updateProfile(Request $request)
+    {
+        $user = auth()->user();
+        if (!$user->staff) {
+            abort(403, 'Akun Anda belum terhubung dengan data staff.');
+        }
+
+        $staff = $user->staff;
+
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'phone' => 'nullable|string|max:20',
+            'position' => 'nullable|string|max:255',
+            'password' => 'nullable|string|min:6|confirmed',
+        ]);
+
+        $staff->update([
+            'name' => $validated['name'],
+            'phone' => $validated['phone'] ?? $staff->phone,
+            'position' => $validated['position'] ?? $staff->position,
+        ]);
+
+        $user->name = $validated['name'];
+        if (!empty($validated['password'])) {
+            $user->password = Hash::make($validated['password']);
+        }
+        $user->save();
+
+        return back()->with('success', 'Profil berhasil diperbarui.');
     }
 }

--- a/resources/views/staff/dashboard.blade.php
+++ b/resources/views/staff/dashboard.blade.php
@@ -96,7 +96,7 @@
                                 <span>Jadwal</span>
                             </a>
                            
-                            <a href="#" class="flex items-center px-4 py-3 text-white hover:bg-white/10 rounded-lg">
+                            <a href="{{ route('staff.profile') }}" class="flex items-center px-4 py-3 text-white hover:bg-white/10 rounded-lg {{ request()->routeIs('staff.profile') ? 'bg-white/20' : '' }}">
                                 <i class="fas fa-user-cog mr-3"></i>
                                 <span>Profil</span>
                             </a>

--- a/resources/views/staff/profile.blade.php
+++ b/resources/views/staff/profile.blade.php
@@ -3,10 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Jadwal Staff Catering</title>
+    <title>Profil Staff</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6/index.global.min.css" rel="stylesheet">
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap');
         body {
@@ -76,7 +75,7 @@
                             </button>
                         </div>
                         <div class="flex items-center">
-                            <span class="text-gray-700 hidden md:block">Jadwal Staff</span>
+                            <span class="text-gray-700 hidden md:block">Profil Staff</span>
                         </div>
                         <div class="flex items-center">
                             <div class="ml-3 relative md:hidden">
@@ -93,22 +92,54 @@
             </div>
             <!-- Main Content -->
             <main class="flex-1 overflow-y-auto bg-gray-50 p-4 md:p-6">
-                <div class="max-w-7xl mx-auto bg-white rounded-2xl shadow-lg p-6">
-                    <div id="calendar"></div>
+                <div class="max-w-3xl mx-auto bg-white rounded-2xl shadow-lg p-6">
+                    @if(session('success'))
+                        <div class="mb-4 p-4 bg-green-100 text-green-800 rounded-lg">
+                            {{ session('success') }}
+                        </div>
+                    @endif
+                    @if ($errors->any())
+                        <div class="mb-4 p-4 bg-red-100 text-red-800 rounded-lg">
+                            <ul class="list-disc pl-5 text-sm">
+                                @foreach ($errors->all() as $error)
+                                    <li>{{ $error }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+                    <form action="{{ route('staff.profile.update') }}" method="POST" class="space-y-4">
+                        @csrf
+                        @method('PUT')
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 mb-1">Nama</label>
+                            <input type="text" name="name" value="{{ old('name', $staff->name) }}" class="w-full border-gray-300 rounded-lg p-2" required>
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 mb-1">Telepon</label>
+                            <input type="text" name="phone" value="{{ old('phone', $staff->phone) }}" class="w-full border-gray-300 rounded-lg p-2">
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 mb-1">Posisi</label>
+                            <input type="text" name="position" value="{{ old('position', $staff->position) }}" class="w-full border-gray-300 rounded-lg p-2">
+                        </div>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1">Password Baru</label>
+                                <input type="password" name="password" class="w-full border-gray-300 rounded-lg p-2" autocomplete="new-password">
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1">Konfirmasi Password</label>
+                                <input type="password" name="password_confirmation" class="w-full border-gray-300 rounded-lg p-2" autocomplete="new-password">
+                            </div>
+                        </div>
+                        <div>
+                            <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">Simpan</button>
+                        </div>
+                    </form>
                 </div>
             </main>
         </div>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6/index.global.min.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function () {
-            var calendar = new FullCalendar.Calendar(document.getElementById('calendar'), {
-                initialView: 'dayGridMonth',
-                events: @json($events)
-            });
-            calendar.render();
-        });
-    </script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const menuButton = document.querySelector('button');

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,13 @@ Route::middleware('auth')
     ->get('/staff/jadwal', [StaffDashboardController::class, 'schedule'])
     ->name('staff.schedule');
 
+Route::middleware('auth')
+    ->get('/staff/profile', [StaffDashboardController::class, 'showProfile'])
+    ->name('staff.profile');
+Route::middleware('auth')
+    ->match(['put', 'patch'], '/staff/profile', [StaffDashboardController::class, 'updateProfile'])
+    ->name('staff.profile.update');
+
 Route::middleware(['auth', 'prevent_staff'])->prefix('staff')->group(function () {
     // Route untuk update status order
     Route::patch('orders/{order}/status', [OrderStatusController::class, 'update'])


### PR DESCRIPTION
## Summary
- add profile routes
- implement profile show/update in `StaffDashboardController`
- create staff profile page with edit form
- link profile page in dashboard and schedule sidebars

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a61a88fb88323b5c2ee5b29277169