### PR TITLE
Add analytics page with export

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ manajemen logistik.
 pengelolaan supplier.
 6. Laporan dan Analitik:
 ▪ Laporan penjualan, analitik menu, pelanggan, serta kinerja staf
+## Analytics Page
+Halaman "Analytics" di panel admin menampilkan ringkasan pendapatan, jumlah pesanan, dan pelanggan baru. Gunakan tombol "Export Excel" atau "Export PDF" untuk mengunduh data bulanan.
+
 
 ### Susunan Tim
 

--- a/app/Filament/Pages/Analytics.php
+++ b/app/Filament/Pages/Analytics.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Models\Customer;
+use App\Models\Order;
+use Filament\Actions\Action;
+use Filament\Pages\Page;
+
+class Analytics extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-chart-bar';
+    protected static ?string $navigationLabel = 'Analytics';
+    protected static ?string $navigationGroup = 'Reports';
+
+    protected static string $view = 'filament.pages.analytics';
+
+    public array $monthlyData = [];
+    public int $revenue = 0;
+    public int $orders = 0;
+    public int $customers = 0;
+
+    public function mount(): void
+    {
+        $this->aggregateData();
+    }
+
+    protected function aggregateData(): void
+    {
+        $this->revenue = Order::where('status', 'completed')->sum('total_price');
+        $this->orders = Order::count();
+        $this->customers = Customer::count();
+
+        $data = [];
+        for ($i = 5; $i >= 0; $i--) {
+            $date = now()->subMonths($i);
+            $data[] = [
+                'month' => $date->format('M Y'),
+                'revenue' => Order::where('status', 'completed')
+                    ->whereYear('created_at', $date->year)
+                    ->whereMonth('created_at', $date->month)
+                    ->sum('total_price'),
+                'orders' => Order::whereYear('created_at', $date->year)
+                    ->whereMonth('created_at', $date->month)
+                    ->count(),
+                'customers' => Customer::whereYear('created_at', $date->year)
+                    ->whereMonth('created_at', $date->month)
+                    ->count(),
+            ];
+        }
+        $this->monthlyData = $data;
+    }
+
+    protected function getActions(): array
+    {
+        return [
+            Action::make('exportExcel')
+                ->label('Export Excel')
+                ->action('exportExcel')
+                ->color('success'),
+            Action::make('exportPdf')
+                ->label('Export PDF')
+                ->action('exportPdf')
+                ->color('primary'),
+        ];
+    }
+
+    public function exportExcel()
+    {
+        $handle = fopen('php://temp', 'r+');
+        fputcsv($handle, ['Month', 'Revenue', 'Orders', 'New Customers']);
+        foreach ($this->monthlyData as $row) {
+            fputcsv($handle, [
+                $row['month'],
+                $row['revenue'],
+                $row['orders'],
+                $row['customers'],
+            ]);
+        }
+        rewind($handle);
+
+        return response()->streamDownload(function () use ($handle) {
+            fpassthru($handle);
+        }, 'analytics.csv');
+    }
+
+    public function exportPdf()
+    {
+        $lines = ['Analytics Summary'];
+        foreach ($this->monthlyData as $row) {
+            $lines[] = sprintf(
+                '%s - Revenue: %s, Orders: %d, Customers: %d',
+                $row['month'],
+                $row['revenue'],
+                $row['orders'],
+                $row['customers'],
+            );
+        }
+
+        $pdf = $this->generatePdf($lines);
+
+        return response($pdf, 200, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => 'attachment; filename="analytics.pdf"',
+        ]);
+    }
+
+    private function generatePdf(array $lines): string
+    {
+        $y = 750;
+        $content = "BT\n/F1 12 Tf\n";
+        foreach ($lines as $line) {
+            $content .= "1 0 0 1 50 $y Tm ($line) Tj\n";
+            $y -= 16;
+        }
+        $content .= "ET";
+        $len = strlen($content);
+
+        $objects = [];
+        $objects[] = "<< /Type /Catalog /Pages 2 0 R >>";
+        $objects[] = "<< /Type /Pages /Kids [3 0 R] /Count 1 >>";
+        $objects[] = "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>";
+        $objects[] = "<< /Length $len >>\nstream\n$content\nendstream";
+        $objects[] = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+        $pdf = "%PDF-1.4\n";
+        $offsets = [];
+        $offset = strlen($pdf);
+        foreach ($objects as $i => $obj) {
+            $offsets[] = $offset;
+            $pdf .= ($i + 1) . " 0 obj\n" . $obj . "\nendobj\n";
+            $offset = strlen($pdf);
+        }
+
+        $xref = "xref\n0 " . (count($objects) + 1) . "\n0000000000 65535 f \n";
+        foreach ($offsets as $o) {
+            $xref .= sprintf("%010d 00000 n \n", $o);
+        }
+
+        $pdf .= $xref;
+        $pdf .= "trailer\n<< /Root 1 0 R /Size " . (count($objects) + 1) . " >>\n";
+        $pdf .= "startxref\n" . strlen($pdf) . "\n%%EOF";
+
+        return $pdf;
+    }
+}

--- a/resources/views/filament/pages/analytics.blade.php
+++ b/resources/views/filament/pages/analytics.blade.php
@@ -1,0 +1,41 @@
+<x-filament::page>
+    <div class="space-y-4">
+        <h1 class="text-2xl font-bold">Analytics</h1>
+
+        <div class="grid grid-cols-3 gap-4">
+            <div class="p-4 bg-white dark:bg-gray-800 rounded shadow">
+                <p class="text-gray-500">Total Revenue</p>
+                <p class="text-lg font-semibold">{{ number_format($revenue, 0, ',', '.') }}</p>
+            </div>
+            <div class="p-4 bg-white dark:bg-gray-800 rounded shadow">
+                <p class="text-gray-500">Total Orders</p>
+                <p class="text-lg font-semibold">{{ $orders }}</p>
+            </div>
+            <div class="p-4 bg-white dark:bg-gray-800 rounded shadow">
+                <p class="text-gray-500">Total Customers</p>
+                <p class="text-lg font-semibold">{{ $customers }}</p>
+            </div>
+        </div>
+
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50 dark:bg-gray-700">
+                <tr>
+                    <th class="px-4 py-2 text-left">Month</th>
+                    <th class="px-4 py-2 text-left">Revenue</th>
+                    <th class="px-4 py-2 text-left">Orders</th>
+                    <th class="px-4 py-2 text-left">New Customers</th>
+                </tr>
+            </thead>
+            <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200">
+                @foreach($monthlyData as $row)
+                    <tr>
+                        <td class="px-4 py-2">{{ $row['month'] }}</td>
+                        <td class="px-4 py-2">{{ number_format($row['revenue'], 0, ',', '.') }}</td>
+                        <td class="px-4 py-2">{{ $row['orders'] }}</td>
+                        <td class="px-4 py-2">{{ $row['customers'] }}</td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+</x-filament::page>


### PR DESCRIPTION
## Summary
- add `Analytics` Filament page to show revenue and order statistics
- allow exporting data to CSV or PDF
- document new page usage in README

## Testing
- `./vendor/bin/pint` *(fails: No such file or directory)*
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684a61c3d6ac8323bf47b30d302ccaba