### PR TITLE
Add purchase order tracking and supplier inventory view

### DIFF
--- a/app/Filament/Resources/PurchaseOrderResource.php
+++ b/app/Filament/Resources/PurchaseOrderResource.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\PurchaseOrderResource\Pages;
+use App\Models\PurchaseOrder;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class PurchaseOrderResource extends Resource
+{
+    protected static ?string $model = PurchaseOrder::class;
+
+    protected static ?string $navigationLabel = 'Purchase Order';
+
+    protected static ?int $navigationSort = 6;
+
+    protected static ?string $navigationGroup = 'Manajemen Produk';
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Select::make('supplier_id')
+                ->relationship('supplier', 'name')
+                ->required()
+                ->label('Supplier'),
+
+            Select::make('inventory_id')
+                ->relationship('inventory', 'item_name')
+                ->required()
+                ->label('Item'),
+
+            TextInput::make('quantity')
+                ->numeric()
+                ->required()
+                ->minValue(1)
+                ->label('Jumlah'),
+
+            Select::make('status')
+                ->options([
+                    'pending' => 'Pending',
+                    'received' => 'Received',
+                    'cancelled' => 'Cancelled',
+                ])
+                ->required()
+                ->label('Status'),
+
+            DatePicker::make('order_date')
+                ->required()
+                ->label('Tanggal Order'),
+
+            DatePicker::make('expected_date')
+                ->label('Estimasi Tiba'),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('supplier.name')
+                    ->label('Supplier')
+                    ->sortable()
+                    ->searchable(),
+
+                TextColumn::make('inventory.item_name')
+                    ->label('Item')
+                    ->sortable()
+                    ->searchable(),
+
+                TextColumn::make('quantity'),
+
+                TextColumn::make('status')
+                    ->badge(),
+
+                TextColumn::make('order_date')
+                    ->date()
+                    ->label('Order'),
+
+                TextColumn::make('expected_date')
+                    ->date()
+                    ->label('Estimasi'),
+            ])
+            ->filters([])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPurchaseOrders::route('/'),
+            'create' => Pages\CreatePurchaseOrder::route('/create'),
+            'edit' => Pages\EditPurchaseOrder::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/PurchaseOrderResource/Pages/CreatePurchaseOrder.php
+++ b/app/Filament/Resources/PurchaseOrderResource/Pages/CreatePurchaseOrder.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\PurchaseOrderResource\Pages;
+
+use App\Filament\Resources\PurchaseOrderResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreatePurchaseOrder extends CreateRecord
+{
+    protected static string $resource = PurchaseOrderResource::class;
+}

--- a/app/Filament/Resources/PurchaseOrderResource/Pages/EditPurchaseOrder.php
+++ b/app/Filament/Resources/PurchaseOrderResource/Pages/EditPurchaseOrder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\PurchaseOrderResource\Pages;
+
+use App\Filament\Resources\PurchaseOrderResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditPurchaseOrder extends EditRecord
+{
+    protected static string $resource = PurchaseOrderResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/PurchaseOrderResource/Pages/ListPurchaseOrders.php
+++ b/app/Filament/Resources/PurchaseOrderResource/Pages/ListPurchaseOrders.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\PurchaseOrderResource\Pages;
+
+use App\Filament\Resources\PurchaseOrderResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPurchaseOrders extends ListRecords
+{
+    protected static string $resource = PurchaseOrderResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/SupplierResource.php
+++ b/app/Filament/Resources/SupplierResource.php
@@ -24,6 +24,7 @@ use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use App\Filament\Resources\SupplierResource\RelationManagers\InventoriesRelationManager;
 
 class SupplierResource extends Resource
 {
@@ -355,7 +356,7 @@ class SupplierResource extends Resource
     public static function getRelations(): array
     {
         return [
-
+            RelationManagers\InventoriesRelationManager::class,
         ];
     }
 

--- a/app/Filament/Resources/SupplierResource/RelationManagers/InventoriesRelationManager.php
+++ b/app/Filament/Resources/SupplierResource/RelationManagers/InventoriesRelationManager.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Filament\Resources\SupplierResource\RelationManagers;
+
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class InventoriesRelationManager extends RelationManager
+{
+    protected static string $relationship = 'inventory';
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('item_name')
+                    ->required(),
+                Forms\Components\TextInput::make('quantity')
+                    ->numeric()
+                    ->required(),
+                Forms\Components\TextInput::make('unit')
+                    ->required(),
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('item_name')
+                    ->label('Item'),
+                Tables\Columns\TextColumn::make('quantity'),
+                Tables\Columns\TextColumn::make('unit'),
+            ]);
+    }
+}

--- a/app/Models/PurchaseOrder.php
+++ b/app/Models/PurchaseOrder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PurchaseOrder extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'supplier_id',
+        'inventory_id',
+        'quantity',
+        'status',
+        'order_date',
+        'expected_date',
+    ];
+
+    protected $casts = [
+        'order_date' => 'date',
+        'expected_date' => 'date',
+    ];
+
+    public function supplier()
+    {
+        return $this->belongsTo(Supplier::class);
+    }
+
+    public function inventory()
+    {
+        return $this->belongsTo(Inventory::class);
+    }
+}

--- a/database/migrations/2025_03_19_073759_create_purchase_orders_table.php
+++ b/database/migrations/2025_03_19_073759_create_purchase_orders_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('purchase_orders', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('supplier_id')->constrained('suppliers')->onDelete('cascade');
+            $table->foreignId('inventory_id')->constrained('inventory')->onDelete('cascade');
+            $table->integer('quantity');
+            $table->enum('status', ['pending', 'received', 'cancelled'])->default('pending');
+            $table->date('order_date');
+            $table->date('expected_date')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('purchase_orders');
+    }
+};


### PR DESCRIPTION
## Summary
- add PurchaseOrder model and migration
- provide PurchaseOrderResource with Filament pages
- link supplier inventory via InventoriesRelationManager
- expose inventories on supplier detail view

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684a61c4e9f4832388fccb409386c82e