### PR TITLE
Implement supplier export

### DIFF
--- a/app/Exports/SuppliersExport.php
+++ b/app/Exports/SuppliersExport.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Exports;
+
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+
+class SuppliersExport implements FromCollection, WithHeadings
+{
+    protected Collection $suppliers;
+
+    public function __construct(Collection $suppliers)
+    {
+        $this->suppliers = $suppliers;
+    }
+
+    public function collection()
+    {
+        return $this->suppliers->map(function ($supplier) {
+            return [
+                'ID' => $supplier->id,
+                'Name' => $supplier->name,
+                'Contact' => $supplier->contact,
+                'Address' => $supplier->address,
+            ];
+        });
+    }
+
+    public function headings(): array
+    {
+        return ['ID', 'Name', 'Contact', 'Address'];
+    }
+}

--- a/app/Filament/Resources/SupplierResource.php
+++ b/app/Filament/Resources/SupplierResource.php
@@ -345,8 +345,31 @@ class SupplierResource extends Resource
                     Tables\Actions\BulkAction::make('exportSelected')
                         ->label('Export Selected')
                         ->icon('heroicon-o-document-arrow-down')
-                        ->action(function (Collection $records): void {
-                            // Logika untuk export data
+                        ->form([
+                            Select::make('format')
+                                ->label('Export Format')
+                                ->options([
+                                    'xlsx' => 'Excel',
+                                    'pdf' => 'PDF',
+                                ])
+                                ->required(),
+                        ])
+                        ->action(function (Collection $records, array $data) {
+                            if ($data['format'] === 'pdf') {
+                                $pdf = \Barryvdh\DomPDF\Facade\Pdf::loadView('exports.suppliers', [
+                                    'suppliers' => $records,
+                                ]);
+
+                                return response()->streamDownload(
+                                    fn () => print($pdf->output()),
+                                    'suppliers.pdf'
+                                );
+                            }
+
+                            return \Maatwebsite\Excel\Facades\Excel::download(
+                                new \App\Exports\SuppliersExport($records),
+                                'suppliers.xlsx'
+                            );
                         }),
                 ]),
             ]);

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,9 @@
         "php": "^8.2",
         "filament/filament": "^3.2",
         "laravel/framework": "^11.31",
-        "laravel/tinker": "^2.9"
+        "laravel/tinker": "^2.9",
+        "maatwebsite/excel": "^3.1",
+        "barryvdh/laravel-dompdf": "^2.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/database/factories/SupplierFactory.php
+++ b/database/factories/SupplierFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Supplier;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SupplierFactory extends Factory
+{
+    protected $model = Supplier::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->company,
+            'contact' => $this->faker->phoneNumber,
+            'address' => $this->faker->address,
+        ];
+    }
+}

--- a/resources/views/exports/suppliers.blade.php
+++ b/resources/views/exports/suppliers.blade.php
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Suppliers Export</title>
+    <style>
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid #000; padding: 5px; text-align: left; }
+    </style>
+</head>
+<body>
+    <h1>Suppliers</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Contact</th>
+                <th>Address</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($suppliers as $supplier)
+                <tr>
+                    <td>{{ $supplier->id }}</td>
+                    <td>{{ $supplier->name }}</td>
+                    <td>{{ $supplier->contact }}</td>
+                    <td>{{ $supplier->address }}</td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+</body>
+</html>

--- a/tests/Feature/SupplierPdfViewTest.php
+++ b/tests/Feature/SupplierPdfViewTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use App\Models\Supplier;
+
+it('renders pdf view with suppliers', function () {
+    $suppliers = Supplier::factory()->count(2)->create();
+
+    $html = view('exports.suppliers', ['suppliers' => $suppliers])->render();
+
+    foreach ($suppliers as $supplier) {
+        expect($html)->toContain($supplier->name);
+    }
+});

--- a/tests/Unit/SuppliersExportTest.php
+++ b/tests/Unit/SuppliersExportTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use App\Exports\SuppliersExport;
+use App\Models\Supplier;
+use Illuminate\Support\Collection;
+
+it('exports suppliers to collection with headings', function () {
+    $suppliers = Supplier::factory()->count(2)->create();
+
+    $export = new SuppliersExport($suppliers);
+
+    $rows = $export->collection();
+
+    expect($rows)->toHaveCount(2)
+        ->and($rows->first())->toHaveKeys(['ID', 'Name', 'Contact', 'Address']);
+});


### PR DESCRIPTION
## Summary
- enable exporting suppliers to Excel or PDF
- create `SuppliersExport` class
- add PDF export view
- add factory and tests for exports
- require Excel and DOMPDF packages

## Testing
- `php artisan test` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a61f34fa08323bddfc8d72376ecfe