### PR TITLE
Fix SupplierResource relation manager

### DIFF
--- a/app/Filament/Resources/SupplierResource.php
+++ b/app/Filament/Resources/SupplierResource.php
@@ -379,7 +379,7 @@ class SupplierResource extends Resource
     public static function getRelations(): array
     {
         return [
-            RelationManagers\InventoriesRelationManager::class,
+            InventoriesRelationManager::class,
         ];
     }
 


### PR DESCRIPTION
## Summary
- fix getRelations method to use the imported InventoriesRelationManager class

## Testing
- `composer dump-autoload` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a6ed474348323a1c3fe04a3e7ac57